### PR TITLE
Nissix plugin scope-packages on react-worker-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "author": "Parashuram <code@nparashuram.com>",
   "license": "BSD-3-Clause",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-core": "^6.2.1",
     "babel-loader": "^6.2.0",


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.211s



Output Log:
Migrating package "react-worker-dom" in .


## Migration from non scope to @wix/scoped packages
> /tmp/cbfd7af2251773713d3bef6df8a49b83

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

